### PR TITLE
merge init and output into ngModel

### DIFF
--- a/src/cronSelection.js
+++ b/src/cronSelection.js
@@ -7,19 +7,18 @@ angular.module('angular-cron-jobs').directive('cronSelection', ['cronService', f
         restrict: 'EA',
         replace: true,
         transclude: true,
+        require: 'ngModel',
         scope: {
+            ngModel: '=',
             config: '=',
-            output: '=?',
-            init: '=?',
             myFrequency: '=?frequency'
         },
         templateUrl: function(element, attributes) {
             return attributes.template || 'cronselection.html';
         },
-        link: function($scope) {
+        link: function($scope, $el, $attr, $ngModel) {
 
-            var originalInit = undefined;
-            var initChanged = false;
+            var modelChanged = false;
 
             $scope.frequency = [{
                 value: 1,
@@ -41,15 +40,12 @@ angular.module('angular-cron-jobs').directive('cronSelection', ['cronService', f
                 label: 'Year'
             }];
 
-            if (angular.isDefined($scope.init)) {
-                originalInit = angular.copy($scope.init);
-                $scope.myFrequency = cronService.fromCron($scope.init);
-            }
-
-            $scope.$watch('init', function(newValue) {
-                if (angular.isDefined(newValue) && newValue && (newValue !== originalInit)) {
-                    initChanged = true;
+            $scope.$watch('ngModel', function (newValue) {
+                if (angular.isDefined(newValue) && newValue) {
+                    modelChanged = true;
                     $scope.myFrequency = cronService.fromCron(newValue);
+                } else if (newValue === '') {
+                    $scope.myFrequency = undefined;
                 }
             });
 
@@ -75,43 +71,48 @@ angular.module('angular-cron-jobs').directive('cronSelection', ['cronService', f
                 }
             }
 
-            $scope.minuteValue = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55];
-            $scope.hourValue = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23];
-            $scope.dayOfMonthValue = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31];
-            $scope.dayValue = [0, 1, 2, 3, 4, 5, 6];
-            $scope.monthValue = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+            $scope.minuteValues = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55];
+            $scope.hourValues = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23];
+            $scope.dayOfMonthValues = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31];
+            $scope.dayValues = [0, 1, 2, 3, 4, 5, 6];
+            $scope.monthValues = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
-            $scope.$watch('myFrequency', function(n, o) {
-                if (n && (!o || n.base !== o.base) && !initChanged) {
-                    if (n && n.base) {
-                        n.base = parseInt(n.base);
-                    }
-                    if (n && n.base && n.base >= 2) {
-                        n.minuteValue = $scope.minuteValue[0];
-                    }
-
-                    if (n && n.base && n.base >= 3) {
-                        n.hourValue = $scope.hourValue[0];
+            $scope.$watch('myFrequency', function (n, o) {
+                if (n !== undefined) {
+                    if (n && n.base && (!o || n.base !== o.base) && !modelChanged) {
+                        setInitialValuesForBase(n);
+                    } else if (n && n.base && o && o.base) {
+                        modelChanged = false;
                     }
 
-                    if (n && n.base && n.base === 4) {
-                        n.dayValue = $scope.dayValue[0];
-                    }
-
-                    if (n && n.base && n.base >= 5) {
-                        n.dayOfMonthValue = $scope.dayOfMonthValue[0];
-                    }
-
-                    if (n && n.base && n.base === 6) {
-                        n.monthValue = $scope.monthValue[0];
-                    }
-                } else if (n && n.base && o && o.base) {
-                    initChanged = false;
+                    var newVal = cronService.setCron(n);
+                    $ngModel.$setViewValue(newVal);
                 }
-                $scope.output = cronService.setCron(n);
             }, true);
 
+            function setInitialValuesForBase(freq) {
+                freq.base = parseInt(freq.base);
 
+                if (freq.base >= 2) {
+                    freq.minuteValue = $scope.minuteValues[0];
+                }
+
+                if (freq.base >= 3) {
+                    freq.hourValue = $scope.hourValues[0];
+                }
+
+                if (freq.base === 4) {
+                    freq.dayValue = $scope.dayValues[0];
+                }
+
+                if (freq.base >= 5) {
+                    freq.dayOfMonthValue = $scope.dayOfMonthValues[0];
+                }
+
+                if (freq.base === 6) {
+                    freq.monthValue = $scope.monthValues[0];
+                }
+            }
         }
     };
 }]).filter('cronNumeral', function() {

--- a/src/cronService.js
+++ b/src/cronService.js
@@ -53,7 +53,7 @@ angular.module('angular-cron-jobs').factory('cronService', function() {
                 for (var i = 0; i < tempArray.length; i++) { tempArray[i] = +tempArray[i]; }
                 frequency.minuteValue = tempArray;
             } else {
-                frequency.minuteValue = [parseInt(cron[0])];
+                frequency.minuteValue = parseInt(cron[0]);
             }
         }
         if (cron[1] !== '*') {
@@ -63,7 +63,7 @@ angular.module('angular-cron-jobs').factory('cronService', function() {
                 for (var i = 0; i < tempArray.length; i++) { tempArray[i] = +tempArray[i]; }
                 frequency.hourValue = tempArray;
             } else {
-                frequency.hourValue = [parseInt(cron[1])];
+                frequency.hourValue = parseInt(cron[1]);
             }
         }
         if (cron[2] !== '*') {
@@ -73,7 +73,7 @@ angular.module('angular-cron-jobs').factory('cronService', function() {
                 for (var i = 0; i < tempArray.length; i++) { tempArray[i] = +tempArray[i]; }
                 frequency.dayOfMonthValue = tempArray;
             } else {
-                frequency.dayOfMonthValue = [parseInt(cron[2])];
+                frequency.dayOfMonthValue = parseInt(cron[2]);
             }
         }
         if (cron[3] !== '*') {
@@ -83,7 +83,7 @@ angular.module('angular-cron-jobs').factory('cronService', function() {
                 for (var i = 0; i < tempArray.length; i++) { tempArray[i] = +tempArray[i]; }
                 frequency.monthValue = tempArray;
             } else {
-                frequency.monthValue = [parseInt(cron[3])];
+                frequency.monthValue = parseInt(cron[3]);
             }
         }
         if (cron[4] !== '*') {
@@ -93,7 +93,7 @@ angular.module('angular-cron-jobs').factory('cronService', function() {
                 for (var i = 0; i < tempArray.length; i++) { tempArray[i] = +tempArray[i]; }
                 frequency.dayValue = tempArray;
             } else {
-                frequency.dayValue = [parseInt(cron[4])];
+                frequency.dayValue = parseInt(cron[4]);
             }
         }
         return frequency;

--- a/src/cronselection.html
+++ b/src/cronselection.html
@@ -8,72 +8,57 @@
         <div ng-show="myFrequency.base == 4" class="cron-select-wrap">
             <!-- If Multiple is Enabled -->
             <select class="cron-select day-value" ng-model="myFrequency.dayValue" ng-if="allowMultiple" multiple>
-                <option ng-repeat="value in dayValue" ng-selected="myFrequency.dayValue.indexOf(value) >= 0" value="{{value}}">
+                <option ng-repeat="value in dayValues" ng-selected="myFrequency.dayValue.indexOf(value) >= 0" value="{{value}}">
                     {{value | cronDayName}}
                 </option>
             </select>
             <!-- If Multiple is not Enabled -->
-            <select class="cron-select day-value" ng-model="myFrequency.dayValue" ng-if="!allowMultiple">
-                <option ng-repeat="value in dayValue" ng-selected="myFrequency.dayValue.indexOf(value) >= 0" value="{{value}}">
-                    {{value | cronDayName}}
-                </option>
+            <select class="cron-select day-value" ng-model="myFrequency.dayValue" ng-options="o for o in dayValues" ng-if="!allowMultiple">
             </select>
         </div>
         <span ng-show="myFrequency.base >= 5">on the </span>
         <div ng-show="myFrequency.base >= 5" class="cron-select-wrap">
             <!-- If Multiple is Enabled -->
             <select class="cron-select day-of-month-value" ng-model="myFrequency.dayOfMonthValue" ng-if="allowMultiple" multiple>
-                <option ng-repeat="value in dayOfMonthValue" ng-selected="myFrequency.dayOfMonthValue.indexOf(value) >= 0" value="{{value}}">
+                <option ng-repeat="value in dayOfMonthValues" ng-selected="myFrequency.dayOfMonthValue.indexOf(value) >= 0" value="{{value}}">
                     {{value | cronNumeral}}
                 </option>
             </select>
 
-            <select class="cron-select day-of-month-value" ng-model="myFrequency.dayOfMonthValue" ng-if="!allowMultiple">
-                <option ng-repeat="value in dayOfMonthValue" ng-selected="myFrequency.dayOfMonthValue.indexOf(value) >= 0" value="{{value}}">
-                    {{value | cronNumeral}}
-                </option>
+            <select class="cron-select day-of-month-value" ng-model="myFrequency.dayOfMonthValue" ng-options="o for o in dayOfMonthValues" ng-if="!allowMultiple">
             </select>
         </div>
         <span ng-show="myFrequency.base == 6">of </span>
         <div ng-show="myFrequency.base == 6" class="cron-select-wrap">
             <select class="cron-select month-value" ng-model="myFrequency.monthValue" ng-if="allowMultiple" multiple>
-                <option ng-repeat="value in monthValue" ng-selected="myFrequency.monthValue.indexOf(value) >= 0" value="{{value}}">
+                <option ng-repeat="value in monthValues" ng-selected="myFrequency.monthValue.indexOf(value) >= 0" value="{{value}}">
                     {{value | cronMonthName}}
                 </option>
             </select>
 
-            <select class="cron-select month-value" ng-model="myFrequency.monthValue" ng-if="!allowMultiple">
-                <option ng-repeat="value in monthValue" ng-selected="myFrequency.monthValue.indexOf(value) >= 0" value="{{value}}">
-                    {{value | cronMonthName}}
-                </option>
+            <select class="cron-select month-value" ng-model="myFrequency.monthValue" ng-options="o for o in monthValues" ng-if="!allowMultiple">
             </select>
         </div>
         <span ng-show="myFrequency.base >= 2">at </span>
         <div ng-show="myFrequency.base >= 3" class="cron-select-wrap">
             <select class="cron-select hour-value" ng-model="myFrequency.hourValue" ng-if="allowMultiple" multiple>
-                <option ng-repeat="value in hourValue" ng-selected="myFrequency.hourValue.indexOf(value) >= 0" value="{{value}}">
+                <option ng-repeat="value in hourValues" ng-selected="myFrequency.hourValue.indexOf(value) >= 0" value="{{value}}">
                     {{value}}
                 </option>
             </select>
 
-            <select class="cron-select hour-value" ng-model="myFrequency.hourValue" ng-if="!allowMultiple">
-                <option ng-repeat="value in hourValue" ng-selected="myFrequency.hourValue.indexOf(value) >= 0" value="{{value}}">
-                    {{value}}
-                </option>
+            <select class="cron-select hour-value" ng-model="myFrequency.hourValue" ng-options="o for o in hourValues" ng-if="!allowMultiple">
             </select>
         </div>
         <span ng-show="myFrequency.base >= 3"> : </span>
         <div ng-show="myFrequency.base >= 2" class="cron-select-wrap">
             <select class="cron-select minute-value" ng-model="myFrequency.minuteValue"  ng-if="allowMultiple" multiple>
-                <option ng-repeat="value in minuteValue" ng-selected="myFrequency.minuteValue.indexOf(value) >= 0" value="{{value}}">
+                <option ng-repeat="value in minuteValues" ng-selected="myFrequency.minuteValue.indexOf(value) >= 0" value="{{value}}">
                     {{value}}
                 </option>
             </select>
 
-            <select class="cron-select minute-value" ng-model="myFrequency.minuteValue"  ng-if="!allowMultiple">
-                <option ng-repeat="value in minuteValue" ng-selected="myFrequency.minuteValue.indexOf(value) >= 0" value="{{value}}">
-                    {{value}}
-                </option>
+            <select class="cron-select minute-value" ng-model="myFrequency.minuteValue" ng-options="o for o in minuteValues" ng-if="!allowMultiple">
             </select>
         </div>
         <span ng-show="myFrequency.base == 2"> past the hour</span>

--- a/test/angularCronJobsSpec.js
+++ b/test/angularCronJobsSpec.js
@@ -17,11 +17,51 @@ describe('AngularCronJobs', function() {
                 allowMinute : false
             }
         };
-        var element = angular.element('<cron-selection config="config"></cron-selection>');
+        var element = angular.element('<cron-selection ng-model="cron" config="config"></cron-selection>');
         var elementCompiled = $compile(element)(scope);
         $rootScope.$digest();
         return elementCompiled;
     }
+
+    it("cronService.fromCron: '15 * * * *' should have minutes set and base mode 2", function() {
+        expect(cronService.fromCron('15 * * * *')).toEqual({base: 2, minuteValue: 15});
+    });
+
+    it("cronService.fromCron: '20 19 * * *' should have minutes and hours set and base mode 3", function() {
+        expect(cronService.fromCron('20 19 * * *')).toEqual({base: 3, minuteValue: 20, hourValue: 19});
+    });
+
+    it("cronService.fromCron: '25 1 * * 3' should have minutes and hours set and base mode 4", function() {
+        expect(cronService.fromCron('25 1 * * 3')).toEqual({base: 4, minuteValue: 25, hourValue: 1, dayValue: 3});
+    });
+
+    it("cronService.fromCron: '30 10 7 * *' should have minutes and hours set and base mode 5", function() {
+        expect(cronService.fromCron('30 10 7 * *')).toEqual({base: 5, minuteValue: 30, hourValue: 10, dayOfMonthValue: 7});
+    });
+
+    it("cronService.fromCron: '35 23 29 4 *' should have minutes and hours set and base mode 6", function() {
+        expect(cronService.fromCron('35 23 29 4 *')).toEqual({base: 6, minuteValue: 35, hourValue: 23, dayOfMonthValue: 29, monthValue: 4});
+    });
+
+    it("cronService.fromCron: '10,15 * * * *' should have minutes set and base mode 2", function() {
+        expect(cronService.fromCron('10,15 * * * *')).toEqual({base: 2, minuteValue: [10,15]});
+    });
+
+    it("cronService.fromCron: '15,20 18,19 * * *' should have minutes and hours set and base mode 3", function() {
+        expect(cronService.fromCron('15,20 18,19 * * *')).toEqual({base: 3, minuteValue: [15,20], hourValue: [18,19]});
+    });
+
+    it("cronService.fromCron: '20,25 1 * * 3' should have minutes and hours set and base mode 4", function() {
+        expect(cronService.fromCron('20,25 1 * * 2,3')).toEqual({base: 4, minuteValue: [20,25], hourValue: 1, dayValue: [2,3]});
+    });
+
+    it("cronService.fromCron: '25,30 9,10 6,7 * *' should have minutes and hours set and base mode 5", function() {
+        expect(cronService.fromCron('25,30 9,10 6,7 * *')).toEqual({base: 5, minuteValue: [25,30], hourValue: [9,10], dayOfMonthValue: [6,7]});
+    });
+
+    it("cronService.fromCron: '35 23 29 3,4 *' should have minutes and hours set and base mode 6", function() {
+        expect(cronService.fromCron('35 23 29 3,4 *')).toEqual({base: 6, minuteValue: 35, hourValue: 23, dayOfMonthValue: 29, monthValue: [3,4]});
+    });
 
     it("cron should be set for every minute", function() {
         var scope = $rootScope.$new();
@@ -86,25 +126,6 @@ describe('AngularCronJobs', function() {
         expect(scope.cron).toEqual('10 4 5,6 5,6 *');
     });
 
-    it("cron with init '15 * * * *' should have minutes set and base mode 2", function() {
-        expect(cronService.fromCron('15 * * * *')).toEqual({base: 2, minuteValue: [15]});
-    });
-
-    it("cron with init '20 19 * * *' should have minutes and hours set and base mode 3", function() {
-        expect(cronService.fromCron('20 19 * * *')).toEqual({base: 3, minuteValue: [20], hourValue: [19]});
-    });
-
-    it("cron with init '25 1 * * 3' should have minutes and hours set and base mode 4", function() {
-        expect(cronService.fromCron('25 1 * * 3')).toEqual({base: 4, minuteValue: [25], hourValue: [1], dayValue: [3]});
-    });
-
-    it("cron with init '30 10 7 * *' should have minutes and hours set and base mode 5", function() {
-        expect(cronService.fromCron('30 10 7 * *')).toEqual({base: 5, minuteValue: [30], hourValue: [10], dayOfMonthValue: [7]});
-    });
-
-    it("cron with init '35 23 29 4 *' should have minutes and hours set and base mode 6", function() {
-        expect(cronService.fromCron('35 23 29 4 *')).toEqual({base: 6, minuteValue: [35], hourValue: [23], dayOfMonthValue: [29], monthValue: [4]});
-    });
 
     it("cron should disallow minute if set in config", function() {
         var scope = $rootScope.$new();


### PR DESCRIPTION
Besides the merging itself I took liberty of refactoring couple things. Hope you don't mind.
`$scope.minuteValue` and similar are renamed into `$scope.minuteValues` to make better semantic sense.

A bunch of code that deals with resetting `myFrequency` is moved into its own function: `setInitialValuesForBase`.

Also there is a breaking change--though I think it makes better sense: even though `allowMultiple` option is selected to be `true`, single values will end up as regular values (not arrays) in myFrequncy. Ex:
* `5 * * * *` will become `{base: 2, minuteValue: 5}`
* but `5,10 * * * *` will be `{base: 2, minuteValue: [5,10]}`
Another reason for this is that I could not make it work the other way with angular-material template that I use in my app.

Tests are updated appropriately.

Addresses #41 and partially #22